### PR TITLE
🚑 Fix broken `supplier_config` reference

### DIFF
--- a/src/var/task/handler.py
+++ b/src/var/task/handler.py
@@ -94,7 +94,7 @@ def handler(event, context):  # pylint: disable=unused-argument
             )
 
             # Slack Technical Contact
-            if supplier_config[2]:
+            if supplier_config["slack_channel"]:
                 send_slack(
                     slack_channel=supplier_config["slack_channel"],
                     message=f"A file uploaded by `{supplier}` has been quarantined.\n  • `{file_name}`",


### PR DESCRIPTION
This pull request:

- Fixes a broken reference to `supplier_config[2]` which was amended in https://github.com/ministryofjustice/analytical-platform-ingestion-notify/pull/27

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 