### PR TITLE
🩹 Use Public ECR for Trivy artifacts

### DIFF
--- a/.github/workflows/scan-image.yml
+++ b/.github/workflows/scan-image.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Scan Image
         id: scan_image
         uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8 # v0.24.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
         with:
           image-ref: ingestion-notify
           exit-code: 1


### PR DESCRIPTION
This pull request:

Switches Trivy action to use ECR instead of GHCR (https://github.com/aquasecurity/trivy-action/issues/389)